### PR TITLE
cygwin pathsep fix

### DIFF
--- a/UUID.h
+++ b/UUID.h
@@ -53,7 +53,7 @@
 
 #define UUID_STATE			".UUID_STATE"
 #define UUID_NODEID			".UUID_NODEID"
-#if defined __mingw32__ || defined _WIN32 || defined _MSC_VER
+#if defined __mingw32__ || (defined _WIN32 && !defined(__cygwin__)) || defined _MSC_VER
 #define UUID_STATE_NV_STORE		_STDIR"\\"UUID_STATE
 #define UUID_NODEID_NV_STORE		_STDIR"\\"UUID_NODEID
 #else


### PR DESCRIPTION
# include <windows.h>

defines _WIN32.
So the subsequent
  #if defined __mingw32__ || defined _WIN32 || defined _MSC_VER
fails for cygwin, leading  at every cpan start to

cygwin warning:
  MS-DOS style path detected: /tmp\.UUID_STATE
  Preferred POSIX equivalent is: /tmp/.UUID_STATE
  CYGWIN environment variable option "nodosfilewarning" turns off this warning.
  Consult the user's guide for more details about POSIX paths:
    http://cygwin.com/cygwin-ug-net/using.html#using-pathnames
