### PR TITLE
Threads test

### DIFF
--- a/t/threads.t
+++ b/t/threads.t
@@ -7,7 +7,8 @@ BEGIN {
     plan skip_all => 'Perl not compiled with useithreads'
         if !$Config{useithreads};
     plan skip_all => 'This test does not cope well with this version of perl'
-        if "$]" == 5.008_002;
+        if "$]" == 5.008_002
+        or ("$]" < 5.013_004 and not $ENV{AUTHOR_TESTING});
     plan tests => 4;
 }
 


### PR DESCRIPTION
t/threads.t hangs on perl 5.8.2 and may crash during thread destruction for any perl before 5.13.4. This branch changes the test to only run if perl is newer than 5.13.4 or if AUTHOR_TESTING is set.
