### PR TITLE
xor the random number seed with the pid

### DIFF
--- a/UUID.xs
+++ b/UUID.xs
@@ -118,7 +118,10 @@ static unsigned16 true_random(void) {
    if (!inited) {
       get_system_time(&time_now);
       time_now = time_now/UUIDS_PER_TICK;
-      srand((unsigned int)(((time_now >> 32) ^ time_now)&0xffffffff));
+      unsigned int seed = (unsigned int)(((time_now >> 32) ^ time_now)&0xffffffff);
+      pid_t pid = getpid();
+      seed ^= pid;
+      srand(seed);
       inited = 1;
     };
     return (rand());


### PR DESCRIPTION
This prevents 2 processes starting at the same microsecond (e.g. after a fork) from generating the same UUID. This fixes the bug reported at https://blog.afoolishmanifesto.com/posts/log-loss-detection/