### PR TITLE
Eliminate use of state/node files in temp directory

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -89,7 +89,7 @@ WriteMakefile(
 
   CONFIGURE           => sub {
     my %opt;
-    GetOptions(\%opt, 's|state-storage-directory:s', 'd|default-umask:s',
+    GetOptions(\%opt, 's|state-storage-directory:s',
         'help|?', 'man') or pod2usage(2);
     pod2usage(1) if $opt{help};
     pod2usage(-verbose => 2) if $opt{man};
@@ -101,18 +101,11 @@ WriteMakefile(
     print "\tUUID state storage: $d\n";
     $d =~ s/\\/\\\\/g if $^O eq 'MSWin32';
 
-    my $m = '0007';
-    unless ($^O eq 'MSWin32') {
-        $m = $opt{d} || $m;
-        print "\tdefault umask: $m\n";
-    }
-
     chmod(0666, sprintf("%s/%s", $d, ".UUID_NODEID"));
     chmod(0666, sprintf("%s/%s", $d, ".UUID_STATE"));
     return {
       DEFINE => '-D_STDIR=' . shell_quote(c_quote($d))
               . ' -D' . shell_quote("__$Config{osname}__")
-              . ' -D_DEFAULT_UMASK=' . shell_quote($m)
            };
   }
 );
@@ -127,11 +120,10 @@ Makefile.PL - configure Makefile for Data::UUID
 
 perl Makefile.PL [options] [EU::MM options]
 
-perl Makefile.PL -s=/var/local/lib/data-uuid -d=0007
+perl Makefile.PL -s=/var/local/lib/data-uuid
 
     Options:
     --state-storage-directory   directory for storing library state information
-    --default-umask             umask for files in the state storage directory
     --help                      brief help message
     --man                       full documentation
 
@@ -148,11 +140,6 @@ state information. Default is c:/tmp/ on Windows if it already exists, or the
 operating system's temporary directory (see tmpdir in L<File::Spec/"METHODS">),
 or /var/tmp as fallback.
 
-=item --default-umask
-
-Optional. Takes a string that is interpreted as umask for the files in the state
-storage directory. Default is 0007. This is ignored on Windows.
-
 =item --help
 
 Print a brief help message and exits.
@@ -166,9 +153,8 @@ Prints the manual page and exits.
 =head1 DESCRIPTION
 
 B<Makefile.PL> writes the Makefile for the Data::UUID library. It is configured
-with the options L</"--state-storage-directory"> and L</"--default-umask">.
-Unless given, default values are used. In any case the values are printed for
-confirmation.
+with the options L</"--state-storage-directory">.  Unless given, default values
+are used. In any case the values are printed for confirmation.
 
 Additionally, the usual EU::MM options are processed, see
 L<ExtUtils::MakeMaker/"Using Attributes and Parameters">.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -89,23 +89,14 @@ WriteMakefile(
 
   CONFIGURE           => sub {
     my %opt;
-    GetOptions(\%opt, 's|state-storage-directory:s',
-        'help|?', 'man') or pod2usage(2);
+    GetOptions(\%opt, 'help|?', 'man') or pod2usage(2);
     pod2usage(1) if $opt{help};
     pod2usage(-verbose => 2) if $opt{man};
 
     print "Configured options (run perl Makefile.PL --help for how to change this):\n";
 
-    my $d = File::Spec->tmpdir;
-    $d = $opt{s} || $d;
-    print "\tUUID state storage: $d\n";
-    $d =~ s/\\/\\\\/g if $^O eq 'MSWin32';
-
-    chmod(0666, sprintf("%s/%s", $d, ".UUID_NODEID"));
-    chmod(0666, sprintf("%s/%s", $d, ".UUID_STATE"));
     return {
-      DEFINE => '-D_STDIR=' . shell_quote(c_quote($d))
-              . ' -D' . shell_quote("__$Config{osname}__")
+      DEFINE => ' -D' . shell_quote("__$Config{osname}__")
            };
   }
 );
@@ -120,10 +111,9 @@ Makefile.PL - configure Makefile for Data::UUID
 
 perl Makefile.PL [options] [EU::MM options]
 
-perl Makefile.PL -s=/var/local/lib/data-uuid
+perl Makefile.PL
 
     Options:
-    --state-storage-directory   directory for storing library state information
     --help                      brief help message
     --man                       full documentation
 
@@ -132,13 +122,6 @@ Options can be abbreviated, see L<Getopt::Long/"Case and abbreviations">.
 =head1 OPTIONS
 
 =over
-
-=item --state-storage-directory
-
-Optional. Takes a string that is interpreted as directory for storing library
-state information. Default is c:/tmp/ on Windows if it already exists, or the
-operating system's temporary directory (see tmpdir in L<File::Spec/"METHODS">),
-or /var/tmp as fallback.
 
 =item --help
 
@@ -152,9 +135,7 @@ Prints the manual page and exits.
 
 =head1 DESCRIPTION
 
-B<Makefile.PL> writes the Makefile for the Data::UUID library. It is configured
-with the options L</"--state-storage-directory">.  Unless given, default values
-are used. In any case the values are printed for confirmation.
+B<Makefile.PL> writes the Makefile for the Data::UUID library.
 
 Additionally, the usual EU::MM options are processed, see
 L<ExtUtils::MakeMaker/"Using Attributes and Parameters">.

--- a/README
+++ b/README
@@ -23,15 +23,6 @@ To install this module type the following:
    make test
    make install
 
-NOTE: This module is designed to save its state information in a permanent 
-storage location. The installation script (i.e. Makefile.PL) prompts for 
-a directory name to use as a storage location for state file and defaults 
-this directory to "/var/tmp" if no directory name is provided. 
-The installation script will not accept names of directories that do not
-exist, however, it will take the locations, which the installing user
-has no write permissions to. In this case, the state information will not be
-saved, which will maximize the chances of generating duplicate UUIDs.
-
 COPYRIGHT AND LICENCE
 
 Copyright (C) 2001, Alexander Golomshtok

--- a/UUID.h
+++ b/UUID.h
@@ -124,7 +124,6 @@ typedef struct _uuid_state_t {
 typedef struct _uuid_context_t {
    uuid_state_t state;
    uuid_node_t  nodeid;
-   perl_uuid_time_t  next_save;
 } uuid_context_t;
 
 static void format_uuid_v1(

--- a/UUID.h
+++ b/UUID.h
@@ -44,10 +44,6 @@
 #include <process.h>
 #endif
 
-#if !defined _STDIR
-#    define  _STDIR			"/var/tmp"
-#endif
-
 #define UUIDS_PER_TICK 1024
 #ifdef _MSC_VER
 #define I64(C) C##i64

--- a/UUID.h
+++ b/UUID.h
@@ -51,16 +51,6 @@
 #    define  _DEFAULT_UMASK		0007
 #endif
 
-#define UUID_STATE			".UUID_STATE"
-#define UUID_NODEID			".UUID_NODEID"
-#if defined __mingw32__ || (defined _WIN32 && !defined(__cygwin__)) || defined _MSC_VER
-#define UUID_STATE_NV_STORE		_STDIR"\\"UUID_STATE
-#define UUID_NODEID_NV_STORE		_STDIR"\\"UUID_NODEID
-#else
-#define UUID_STATE_NV_STORE		_STDIR"/"UUID_STATE
-#define UUID_NODEID_NV_STORE		_STDIR"/"UUID_NODEID
-#endif
-
 #define UUIDS_PER_TICK 1024
 #ifdef _MSC_VER
 #define I64(C) C##i64

--- a/UUID.h
+++ b/UUID.h
@@ -47,9 +47,6 @@
 #if !defined _STDIR
 #    define  _STDIR			"/var/tmp"
 #endif
-#if !defined _DEFAULT_UMASK
-#    define  _DEFAULT_UMASK		0007
-#endif
 
 #define UUIDS_PER_TICK 1024
 #ifdef _MSC_VER

--- a/UUID.xs
+++ b/UUID.xs
@@ -397,9 +397,6 @@ PPCODE:
    self->state.node = self->nodeid;
    self->state.ts   = timestamp;
    self->state.cs   = clockseq;
-   if (timestamp > self->next_save ) {
-      self->next_save = timestamp + (10 * 10 * 1000 * 1000);
-   }
    ST(0) = make_ret(uuid, ix);
    XSRETURN(1);
 


### PR DESCRIPTION
#5 identifies a security concern due to insecure writing of State/Node files in a temporary directory, with predictable filenames, with a possible symlink attack.

Rather than attempting to address the issue by using more random filenames, or by adding extra logic to ensure that the files are being handled in a secure manner, this PR simply eliminates the use of these files completely.

Unfortunately, the historical reason for why the files were originally needed is lost, but discussion present in #5 posits that they may have been present for performance reasons.

Existing test suite passes without change.

Further, the issue highlighted in #27 regarding "duplicate UUIDs after fork" does not appear to be any worse with these changes to remove the state/node files.  After running the command documented in #27 repeatedly, both before and after this change, I see no increase in the number of duplicate UUIDs.